### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,4 +1,6 @@
 name: Unit Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/IPSubnetPlanner/security/code-scanning/2](https://github.com/microsoft/IPSubnetPlanner/security/code-scanning/2)

The best way to fix this problem is to add a `permissions` block to the workflow, specifying the minimal required permissions. Since the workflow only runs unit tests and does not perform any write operations (such as pushing code, creating issues, or updating pull requests), it is sufficient to grant the workflow read-only access to repository contents. This is done by adding `permissions: contents: read` at the top-level of the workflow file, right after the `name` key and before `on` (so it applies to all jobs by default). No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
