### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -1,4 +1,6 @@
 name: Build Artifacts
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/IPSubnetPlanner/security/code-scanning/1](https://github.com/microsoft/IPSubnetPlanner/security/code-scanning/1)

To address this issue, you should add a `permissions` block either at the root of the workflow (to apply it to all jobs) or within the relevant job(s). Since all jobs in this workflow are performing actions that only require reading repository contents, and do not need to create, modify, or delete content on GitHub, explicitly limiting permissions is best. Specifically, add `permissions: contents: read` just below the workflow's name or at the job level (before `runs-on`). This will restrict the `GITHUB_TOKEN` permissions to only read repository contents, adhering to the principle of least privilege. No additional methods, imports, or other configuration is necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
